### PR TITLE
Add support for nib

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -1,7 +1,8 @@
 // Stylus 'CSS' wrapper for SocketStream 0.3
 
 var fs = require('fs')
-  , stylus = require('stylus');
+  , stylus = require('stylus')
+  , nib = require('nib');
 
 exports.init = function(root, config) {
 
@@ -24,7 +25,9 @@ exports.init = function(root, config) {
 
       var compress = options && options.compress;
 
-      stylus.render(input, {filename: path, paths: [dir.join('/')], compress: compress}, function(err, css) {
+      stylus(input, {filename: path, paths: [dir.join('/')], compress: compress})
+        .use(nib())
+        .render(function(err, css) {
         if (err) {
           console.log('! - Unable to compile Stylus file %s into CSS', path);
           console.log(err);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "node": ">= 0.6.0"
   },
   "dependencies": {
-    "stylus": "0.22.x"
+    "stylus": "0.22.x",
+    "nib": "0.3.x"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Stylus is better with [nib](https://github.com/visionmedia/nib). To use, add:

```
@import 'nib'
```

to the top of a `.styl` file.
