### PR TITLE
Read config and set parameters. resolves #3

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -36,8 +36,11 @@ exports.init = function(root, config) {
         input = _prependedStylus + '\n' + input;
       }
 
-      stylus(input, {filename: path, paths: [dir.join('/')]})
-        .use(nib())
+      var sss = stylus(input, {filename: path, paths: [dir.join('/')]});
+      for (var c in config) {
+        sss.set(c, config[c]);
+      }
+      sss.use(nib())
         .render(function(err, css) {
         if (err) {
           var message = '! - Unable to compile Stylus file %s into CSS';


### PR DESCRIPTION
This pr reads the config parameter and sets all options in stylus.
This enables to do something like:

```
ss.client.formatters.add(require('ss-stylus'), { 'include css' : true });
```

This way css files could be included. Other options are possible as well.
